### PR TITLE
Revert "Http status now matches http body"

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
+++ b/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java
@@ -14,13 +14,8 @@ public class OTPExceptionMapper implements ExceptionMapper<Exception> {
     public Response toResponse(Exception ex) {
         // Show the exception in the server log
         LOG.error("Unhandled exception", ex);
-
-        int statusCode = Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
-        if (ex instanceof WebApplicationException)
-            statusCode = ((WebApplicationException)ex).getResponse().getStatus();
-
         // Return the short form message to the client
-        return Response.status(statusCode)
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(ex.toString() + " " + ex.getMessage())
                 .type("text/plain").build();
     }


### PR DESCRIPTION
Reverts rutebanken/OpenTripPlanner#4

[ERROR] /usr/src/jenkinsbuild/workspace/otp/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java:[19,27] cannot find symbol
  symbol:   class WebApplicationException
  location: class org.opentripplanner.api.common.OTPExceptionMapper
[ERROR] /usr/src/jenkinsbuild/workspace/otp/src/main/java/org/opentripplanner/api/common/OTPExceptionMapper.java:[20,28] cannot find symbol
  symbol:   class WebApplicationException
  location: class org.opentripplanner.api.common.OTPExceptionMapper
[INFO] 2 errors 