### PR TITLE
Bug fix: This fixes 2 bugs in the Netex calendar import.

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/NetexModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NetexModule.java
@@ -3,6 +3,7 @@ package org.opentripplanner.graph_builder.module;
 import org.opentripplanner.calendar.impl.MultiCalendarServiceImpl;
 import org.opentripplanner.graph_builder.services.GraphBuilderModule;
 import org.opentripplanner.graph_builder.triptransformer.TripTransformService;
+import org.opentripplanner.model.OtpTransitService;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.impl.OtpTransitBuilder;
 import org.opentripplanner.netex.loader.NetexBundle;
@@ -51,13 +52,16 @@ public class NetexModule implements GraphBuilderModule {
 
                 TripTransformService.printTimeTable(daoBuilder, configDirectory);
 
+                OtpTransitService otpTransitService = daoBuilder.build();
 
                 PatternHopFactory hf = new PatternHopFactory(
                         new GtfsFeedId.Builder().id(netexBundle.netexParameters.netexFeedId).build(),
-                        daoBuilder.build(), fareServiceFactory,
+                        otpTransitService,
+                        fareServiceFactory,
                         netexBundle.getMaxStopToShapeSnapDistance(),
                         netexBundle.subwayAccessTime,
-                        netexBundle.maxInterlineDistance);
+                        netexBundle.maxInterlineDistance
+                );
                 hf.setStopContext(stopContext);
                 hf.run(graph);
 

--- a/src/main/java/org/opentripplanner/netex/loader/NetexDao.java
+++ b/src/main/java/org/opentripplanner/netex/loader/NetexDao.java
@@ -187,4 +187,11 @@ public class NetexDao {
         this.timeZone = timeZone;
     }
 
+    /**
+     * This is used to be able to create a NetexDao outside the package.
+     * SHOULD ONLY BE USED IN UNIT TESTS.
+     */
+    public static NetexDao createForTest(NetexDao parent) {
+        return parent == null ? new NetexDao() : new NetexDao(parent);
+    }
 }

--- a/src/main/java/org/opentripplanner/netex/loader/NetexLoader.java
+++ b/src/main/java/org/opentripplanner/netex/loader/NetexLoader.java
@@ -135,13 +135,13 @@ public class NetexLoader {
         mapCurrentNetexEntitiesIntoOtpTransitObjects();
 
         for (GroupEntries group : entries.groups()) {
-            newNetexDaoScope(() -> {
+            newDataScope(() -> {
                 // Load shared group files
                 loadFiles("shared group file", group.sharedEntries());
                 mapCurrentNetexEntitiesIntoOtpTransitObjects();
 
                 for (DataSource entry : group.independentEntries()) {
-                    newNetexDaoScope(() -> {
+                    newDataScope(() -> {
                         // Load each independent file in group
                         loadFile("group file", entry);
                         mapCurrentNetexEntitiesIntoOtpTransitObjects();
@@ -156,9 +156,9 @@ public class NetexLoader {
         return netexDaoStack.peekFirst();
     }
 
-    private void newNetexDaoScope(Runnable task) {
+    private void newDataScope(Runnable task) {
         netexDaoStack.addFirst(new NetexDao(currentNetexDao()));
-        otpMapper.putCache();
+        otpMapper.pushCache();
         task.run();
         otpMapper.popCache();
         netexDaoStack.removeFirst();

--- a/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -224,7 +224,7 @@ public class NetexMapper {
      * This method create a new cache so the mapper is ready to map a new level. The cached elements are available
      * until the {@link #popCache()} is called.
      */
-    public void putCache() {
-        serviceCalendarBuilder.putCache();
+    public void pushCache() {
+        serviceCalendarBuilder.pushCache();
     }
 }

--- a/src/main/java/org/opentripplanner/netex/mapping/calendar/CalendarMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/calendar/CalendarMapper.java
@@ -2,14 +2,15 @@ package org.opentripplanner.netex.mapping.calendar;
 
 import org.glassfish.jersey.internal.util.Producer;
 import org.opentripplanner.model.AgencyAndId;
-import org.opentripplanner.model.ServiceCalendarDate;
 import org.opentripplanner.model.TripServiceAlteration;
 import org.opentripplanner.model.calendar.ServiceDate;
-import org.opentripplanner.netex.loader.NetexDao;
+import org.opentripplanner.netex.loader.support.HierarchicalMapById;
+import org.opentripplanner.netex.loader.support.HierarchicalMultimap;
 import org.opentripplanner.netex.mapping.TripServiceAlterationMapper;
 import org.rutebanken.netex.model.DatedServiceJourney;
 import org.rutebanken.netex.model.DayType;
 import org.rutebanken.netex.model.DayTypeAssignment;
+import org.rutebanken.netex.model.OperatingDay;
 import org.rutebanken.netex.model.OperatingPeriod;
 import org.rutebanken.netex.model.PropertyOfDay;
 import org.rutebanken.netex.model.ServiceAlterationEnumeration;
@@ -20,27 +21,30 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 
-// TODO TGR - Add Unit tests
-public class CalendarMapper {
-    public static Map<String, Set<ServiceDate>> mapDayTypesToLocalDates(NetexDao netexDao) {
+class CalendarMapper {
+    static Map<String, Set<ServiceDate>> mapDayTypesToLocalDates(
+        HierarchicalMapById<DayType> dayTypeById,
+        HierarchicalMultimap<String, DayTypeAssignment> dayTypeAssignmentByDayTypeId,
+        HierarchicalMapById<OperatingPeriod> operatingPeriodById
+    ) {
         Map<String, Set<ServiceDate>> result = new HashMap<>();
-        for (String dayTypeId : netexDao.dayTypeById.keys()) {
-            DayType dayType = netexDao.dayTypeById.lookup(dayTypeId);
+        for (String dayTypeId : dayTypeById.keys()) {
+
+            DayType dayType = dayTypeById.lookup(dayTypeId);
             Collection<LocalDateTime> serviceCalendarDatesForDayType = new HashSet<>();
             Collection<LocalDateTime> serviceCalendarDatesRemoveForDayType = new HashSet<>();
 
-            for (DayTypeAssignment dayTypeAssignment : netexDao.dayTypeAssignmentByDayTypeId.lookup(dayTypeId)) {
-                boolean available = dayTypeAssignment.isIsAvailable() == null || dayTypeAssignment.isIsAvailable();
+            for (DayTypeAssignment dtAssignment : dayTypeAssignmentByDayTypeId.lookup(dayTypeId)) {
+                boolean available = dtAssignment.isIsAvailable() == null || dtAssignment.isIsAvailable();
 
                 // Add or remove single days
-                if (dayTypeAssignment.getDate() != null) {
-                    LocalDateTime date = dayTypeAssignment.getDate();
+                if (dtAssignment.getDate() != null) {
+                    LocalDateTime date = dtAssignment.getDate();
                     if (available) {
                         serviceCalendarDatesForDayType.add(date);
                     } else {
@@ -48,83 +52,80 @@ public class CalendarMapper {
                     }
                 }
                 // Add or remove periods
-                else if (dayTypeAssignment.getOperatingPeriodRef() != null &&
-                        netexDao.operatingPeriodById.containsKey(dayTypeAssignment.getOperatingPeriodRef().getRef())) {
-
-                    OperatingPeriod operatingPeriod = netexDao.operatingPeriodById.lookup(dayTypeAssignment.getOperatingPeriodRef().getRef());
+                else if (assignmentHasOperatingPeriod(dtAssignment, operatingPeriodById)) {
+                    OperatingPeriod operatingPeriod = operatingPeriodById.lookup(
+                        dtAssignment.getOperatingPeriodRef().getRef()
+                    );
                     LocalDateTime fromDate = operatingPeriod.getFromDate();
                     LocalDateTime toDate = operatingPeriod.getToDate();
 
                     EnumSet<DayOfWeek> daysOfWeek = EnumSet.noneOf(DayOfWeek.class);
 
                     if (dayType.getProperties() != null) {
-                        List<PropertyOfDay> propertyOfDays = dayType.getProperties().getPropertyOfDay();
-                        for (PropertyOfDay property : propertyOfDays) {
-                            daysOfWeek.addAll(DayOfWeekMapper.mapDayOfWeek(property.getDaysOfWeek()));
+                        for (PropertyOfDay property : dayType.getProperties().getPropertyOfDay()) {
+                            daysOfWeek.addAll(DayOfWeekMapper.mapDayOfWeeks(property.getDaysOfWeek()));
                         }
                     }
 
-                    for (LocalDateTime date = fromDate; date.isBefore(toDate.plusDays(1)); date = date.plusDays(1)) {
-                        // Every day
-                        if (daysOfWeek.size() == 7) {
-                            serviceCalendarDatesForDayType.add(date);
-                        } else {
-                            if(daysOfWeek.contains(date.getDayOfWeek())) {
-                                if (available) {
-                                    serviceCalendarDatesForDayType.add(date);
-                                } else {
-                                    serviceCalendarDatesRemoveForDayType.add(date);
-                                }
+                    LocalDateTime toDateExclusive = toDate.plusDays(1);
+                    for (LocalDateTime date = fromDate; date.isBefore(toDateExclusive); date = date.plusDays(1)) {
+                        if(daysOfWeek.contains(date.getDayOfWeek())) {
+                            if (available) {
+                                serviceCalendarDatesForDayType.add(date);
+                            } else {
+                                serviceCalendarDatesRemoveForDayType.add(date);
                             }
                         }
                     }
                 }
             }
             serviceCalendarDatesForDayType.removeAll(serviceCalendarDatesRemoveForDayType);
-            Set<ServiceDate> existing = result.get(dayTypeId);
+
+            // Map to ServiceDate
             Set<ServiceDate> newDates = serviceCalendarDatesForDayType
                             .stream()
                             .map(d -> new ServiceDate(d.toLocalDate()))
-                            .collect(Collectors.toSet());
+                            // Prevent accidental updates to the set by making it READ-ONLY
+                            .collect(Collectors.toUnmodifiableSet());
 
-            if(existing == null) {
-                result.put(dayTypeId, newDates);
-            }
-            else {
-                existing.addAll(newDates);
-            }
+            // Add to result
+            result.put(dayTypeId, newDates);
         }
         return result;
     }
 
-    public static Map<Collection<ServiceDate>, AgencyAndId> mapDatesToServiceId(
+    static Map<Collection<ServiceDate>, AgencyAndId> mapDatesToServiceId(
             Collection<Set<ServiceDate>> serviceDates,
             Producer<AgencyAndId> serviceIdGenerator
     ) {
         Map<Collection<ServiceDate>, AgencyAndId> serviceIds = new HashMap<>();
-        for (Collection<ServiceDate> dates : serviceDates) {
-            serviceIds.put(dates, serviceIdGenerator.call());
+        for (Set<ServiceDate> dates : serviceDates) {
+            serviceIds.computeIfAbsent(dates, it -> serviceIdGenerator.call());
         }
         return serviceIds;
     }
 
-    static Map<String, Set<ServiceDate>> createDatedServiceJourneyCalendar(NetexDao netexDao) {
-        Map<String, TripServiceAlteration> alternations = new HashMap<>();
+    static Map<String, Set<ServiceDate>> createDatedServiceJourneyCalendar(
+        HierarchicalMapById<DatedServiceJourney> datedServiceJourneyById,
+        HierarchicalMapById<OperatingDay> operatingDaysById
+    ) {
         Map<String, Set<ServiceDate>> map = new HashMap<>();
 
-        for (DatedServiceJourney dsj : netexDao.datedServiceJourneyById.values()) {
+        for (DatedServiceJourney dsj : datedServiceJourneyById.values()) {
             var sjId = dsj.getJourneyRef().get(0).getValue().getRef();
-            var date = netexDao.operatingDaysById.lookup(dsj.getOperatingDayRef().getRef()).getCalendarDate();
+            var date = operatingDaysById.lookup(dsj.getOperatingDayRef().getRef()).getCalendarDate();
             var serviceDate = new ServiceDate(date.toLocalDate());
             map.computeIfAbsent(sjId, k -> new HashSet<>()).add(serviceDate);
         }
         return map;
-        }
+    }
 
-    static Map<String, TripServiceAlteration> tripServiceAlterationsBySJId(NetexDao netexDao) {
+    static Map<String, TripServiceAlteration> tripServiceAlterationsBySJId(
+        final HierarchicalMapById<DatedServiceJourney> datedServiceJourneyById
+    ) {
         Map<String, TripServiceAlteration> alternations = new HashMap<>();
 
-        for (DatedServiceJourney dsj : netexDao.datedServiceJourneyById.values()) {
+        for (DatedServiceJourney dsj : datedServiceJourneyById.values()) {
             var sjId = dsj.getJourneyRef().get(0).getValue().getRef();
             var alt = mapAlterationWithDefaultPlanned(dsj.getServiceAlteration());
 
@@ -143,35 +144,15 @@ public class CalendarMapper {
         return alternations;
     }
 
-
-    public static Collection<ServiceCalendarDate> mapToCalendarDates(
-            String feedId, Collection<DatedServiceJourney> datedSJs, NetexDao netexDao
+    private static boolean assignmentHasOperatingPeriod(
+        DayTypeAssignment dtAssignment,
+        HierarchicalMapById<OperatingPeriod> operatingPeriodById
     ) {
-        var dates = new HashSet<ServiceCalendarDate>();
-
-        for (DatedServiceJourney dsj : datedSJs) {
-            // Generate a service id
-            var serviceId = new AgencyAndId(feedId, "DSJ-" + dsj.getJourneyRef().get(0).getValue().getRef());
-            dates.add(
-                    createServiceCalendarDate(
-                            netexDao.operatingDaysById.lookup(dsj.getOperatingDayRef().getRef()).getCalendarDate(),
-                            serviceId,
-                            ServiceCalendarDate.EXCEPTION_TYPE_ADD
-                    )
-            );
-        }
-        return dates;
+        var ref = dtAssignment.getOperatingPeriodRef();
+        return ref != null && operatingPeriodById.containsKey(ref.getRef());
     }
 
-    private static ServiceCalendarDate createServiceCalendarDate(LocalDateTime date, AgencyAndId serviceId, Integer exceptionType) {
-        return new ServiceCalendarDate(
-                serviceId,
-                new ServiceDate(date.toLocalDate()),
-                exceptionType
-        );
-    }
-
-    public static TripServiceAlteration mapAlterationWithDefaultPlanned(ServiceAlterationEnumeration netexValue) {
+    private static TripServiceAlteration mapAlterationWithDefaultPlanned(ServiceAlterationEnumeration netexValue) {
         if (netexValue == null) {
             return TripServiceAlteration.planned;
         }

--- a/src/main/java/org/opentripplanner/netex/mapping/calendar/DayOfWeekMapper.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/calendar/DayOfWeekMapper.java
@@ -12,7 +12,7 @@ import java.util.Set;
  * "collection" type elements like WEEKDAYS, WEEKEND, EVERYDAY and NONE. Beacuse of this, the
  * mapping is not ono-to-one, but rather one-to-many.
  */
-public class DayOfWeekMapper {
+class DayOfWeekMapper {
 
     /** Utility class with static methods, prevent instantiation with private constructor */
     private DayOfWeekMapper() {}
@@ -23,7 +23,7 @@ public class DayOfWeekMapper {
      * <p>
      * [MONDAY, SATURDAY, WEEKEND] => [MONDAY, SATURDAY, SUNDAY]
      */
-    static Set<DayOfWeek> mapDayOfWeek(Collection<DayOfWeekEnumeration> values) {
+    static Set<DayOfWeek> mapDayOfWeeks(Collection<DayOfWeekEnumeration> values) {
         EnumSet<DayOfWeek> result = EnumSet.noneOf(DayOfWeek.class);
         for (DayOfWeekEnumeration it : values) {
             result.addAll(mapDayOfWeek(it));

--- a/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAndServiceJourneyId.java
+++ b/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAndServiceJourneyId.java
@@ -3,11 +3,11 @@ package org.opentripplanner.netex.mapping.calendar;
 import javax.validation.constraints.NotNull;
 import java.util.Objects;
 
-class DayTypeAndServiceJourneyIds {
+class DayTypeAndServiceJourneyId {
     private final String dayTypeId;
     private final String sjId;
 
-    public DayTypeAndServiceJourneyIds(@NotNull String dayTypeId, @NotNull String sjId) {
+    public DayTypeAndServiceJourneyId(@NotNull String dayTypeId, @NotNull String sjId) {
         this.dayTypeId = dayTypeId;
         this.sjId = sjId;
     }
@@ -29,7 +29,7 @@ class DayTypeAndServiceJourneyIds {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        DayTypeAndServiceJourneyIds that = (DayTypeAndServiceJourneyIds) o;
+        DayTypeAndServiceJourneyId that = (DayTypeAndServiceJourneyId) o;
         return dayTypeId.equals(that.dayTypeId) &&
                 sjId.equals(that.sjId);
     }

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -178,6 +178,9 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
      * The non-interpolated stoptimes should already be marked at timepoints by a previous filtering step.
      */
     public TripTimes(final Trip trip, final Collection<StopTime> stopTimes, final Deduplicator deduplicator) {
+        if(trip == null || stopTimes == null) {
+            throw new IllegalStateException();
+        }
         this.trip = trip;
         final int nStops = stopTimes.size();
         final int[] departures = new int[nStops];
@@ -293,6 +296,9 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
      * stops and have the same schedule, but depart relative to the original.
      */
     public TripTimes(Trip newTrip, int relativeTimeshift,  TripTimes source) {
+        if(newTrip == null) {
+            throw new IllegalArgumentException();
+        }
         this.trip = newTrip;
         this.serviceCode = source.serviceCode;
         this.timeShift = source.timeShift + relativeTimeshift;

--- a/src/test/java/org/opentripplanner/netex/NetexTestDataSupport.java
+++ b/src/test/java/org/opentripplanner/netex/NetexTestDataSupport.java
@@ -1,0 +1,105 @@
+package org.opentripplanner.netex;
+
+import org.rutebanken.netex.model.DatedServiceJourney;
+import org.rutebanken.netex.model.DayOfWeekEnumeration;
+import org.rutebanken.netex.model.DayType;
+import org.rutebanken.netex.model.DayTypeAssignment;
+import org.rutebanken.netex.model.DayTypeRefStructure;
+import org.rutebanken.netex.model.JourneyRefStructure;
+import org.rutebanken.netex.model.OperatingDay;
+import org.rutebanken.netex.model.OperatingDayRefStructure;
+import org.rutebanken.netex.model.OperatingPeriod;
+import org.rutebanken.netex.model.OperatingPeriodRefStructure;
+import org.rutebanken.netex.model.PropertiesOfDay_RelStructure;
+import org.rutebanken.netex.model.PropertyOfDay;
+import org.rutebanken.netex.model.ServiceAlterationEnumeration;
+
+import javax.annotation.Nullable;
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public final class NetexTestDataSupport {
+
+  /** Utility class, prevent instantiation. */
+  private NetexTestDataSupport() {}
+
+
+
+  /* XML TYPES */
+
+  public static <T> JAXBElement<T> jaxbElement(T e, Class<T> clazz) {
+    return new JAXBElement<T>(new QName("x"), clazz, e);
+  }
+
+
+  /* JAVA TYPES*/
+
+  @Nullable
+  public static LocalDateTime createLocalDateTime(LocalDate day) {
+    return day == null ? null : LocalDateTime.of(day, LocalTime.of(12, 0));
+  }
+
+
+  /* NETEX TYPES */
+
+  public static OperatingDay createOperatingDay(String id, LocalDate day) {
+    return new OperatingDay().withId(id).withCalendarDate(createLocalDateTime(day));
+  }
+
+  public static DayType createDayType(String id, DayOfWeekEnumeration ... daysOfWeek) {
+    DayType dayType = new DayType().withId(id);
+    if(daysOfWeek != null && daysOfWeek.length > 0) {
+      dayType.setProperties(
+          new PropertiesOfDay_RelStructure().withPropertyOfDay(
+              new PropertyOfDay().withDaysOfWeek(daysOfWeek)
+          )
+      );
+    }
+    return dayType;
+  }
+
+  public static DayTypeRefStructure createDayTypeRef(String id) {
+    return new DayTypeRefStructure().withRef(id);
+  }
+
+  public static DayTypeAssignment createDayTypeAssignment(String dayTypeId, LocalDate date, Boolean isAvailable) {
+    return new DayTypeAssignment()
+        .withDayTypeRef(jaxbElement(createDayTypeRef(dayTypeId), DayTypeRefStructure.class))
+        .withDate(createLocalDateTime(date))
+        .withIsAvailable(isAvailable);
+  }
+
+  public static DayTypeAssignment createDayTypeAssignment(String dayTypeId, String opPeriodId, Boolean isAvailable) {
+    return new DayTypeAssignment()
+        .withDayTypeRef(jaxbElement(createDayTypeRef(dayTypeId), DayTypeRefStructure.class))
+        .withOperatingPeriodRef(new OperatingPeriodRefStructure().withRef(opPeriodId))
+        .withIsAvailable(isAvailable);
+  }
+
+  public static OperatingPeriod createOperatingPeriod(String id, LocalDate fromDate, LocalDate toDate) {
+    return new OperatingPeriod()
+        .withId(id)
+        .withFromDate(createLocalDateTime(fromDate))
+        .withToDate(createLocalDateTime(toDate));
+  }
+
+  public static DatedServiceJourney createDatedServiceJourney(String id, String opDayId, String sjId) {
+    return createDatedServiceJourney(id, opDayId, sjId, null);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static DatedServiceJourney createDatedServiceJourney(
+      String id, String opDayId, String sjId, ServiceAlterationEnumeration alt
+  ) {
+    var sjRef = jaxbElement(journeyRef(sjId), JourneyRefStructure.class);
+    var odRef = new OperatingDayRefStructure().withRef(opDayId);
+    return new DatedServiceJourney().withId(id).withJourneyRef(sjRef).withOperatingDayRef(odRef).withServiceAlteration(alt);
+  }
+
+  public static JourneyRefStructure journeyRef(String sjId) {
+    return new JourneyRefStructure().withRef(sjId);
+  }
+}

--- a/src/test/java/org/opentripplanner/netex/mapping/calendar/CalendarMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/calendar/CalendarMapperTest.java
@@ -114,12 +114,14 @@ public class CalendarMapperTest {
     }
 
     // WHEN - create calendar
-    var result = CalendarMapper.mapDayTypesToLocalDates(dayTypes, assignments, periods);
+    Map<String, Set<ServiceDate>> result = CalendarMapper.mapDayTypesToLocalDates(
+        dayTypes,
+        assignments,
+        periods
+    );
 
 
     // THEN - verify
-    System.out.println(result);
-
     assertEquals("[2020-10-21]", toStr(result, DAY_TYPE_1));
     assertEquals("[]", toStr(result, DAY_TYPE_2));
     assertEquals(

--- a/src/test/java/org/opentripplanner/netex/mapping/calendar/CalendarMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/calendar/CalendarMapperTest.java
@@ -1,0 +1,228 @@
+package org.opentripplanner.netex.mapping.calendar;
+
+import org.junit.Test;
+import org.opentripplanner.model.AgencyAndId;
+import org.opentripplanner.model.TripServiceAlteration;
+import org.opentripplanner.model.calendar.ServiceDate;
+import org.opentripplanner.netex.loader.support.HierarchicalMapById;
+import org.opentripplanner.netex.loader.support.HierarchicalMultimap;
+import org.rutebanken.netex.model.DatedServiceJourney;
+import org.rutebanken.netex.model.DayType;
+import org.rutebanken.netex.model.DayTypeAssignment;
+import org.rutebanken.netex.model.OperatingDay;
+import org.rutebanken.netex.model.OperatingPeriod;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.opentripplanner.netex.NetexTestDataSupport.createDatedServiceJourney;
+import static org.opentripplanner.netex.NetexTestDataSupport.createDayType;
+import static org.opentripplanner.netex.NetexTestDataSupport.createDayTypeAssignment;
+import static org.opentripplanner.netex.NetexTestDataSupport.createOperatingDay;
+import static org.opentripplanner.netex.NetexTestDataSupport.createOperatingPeriod;
+import static org.rutebanken.netex.model.DayOfWeekEnumeration.EVERYDAY;
+import static org.rutebanken.netex.model.DayOfWeekEnumeration.WEEKDAYS;
+import static org.rutebanken.netex.model.ServiceAlterationEnumeration.CANCELLATION;
+import static org.rutebanken.netex.model.ServiceAlterationEnumeration.EXTRA_JOURNEY;
+import static org.rutebanken.netex.model.ServiceAlterationEnumeration.PLANNED;
+import static org.rutebanken.netex.model.ServiceAlterationEnumeration.REPLACED;
+
+public class CalendarMapperTest {
+
+  private static final String FEED = "F";
+
+  private final static ServiceDate SD1 = new ServiceDate(2020, 10, 1);
+  private final static ServiceDate SD2 = new ServiceDate(2020, 10, 2);
+  private final static ServiceDate SD3 = new ServiceDate(2020, 10, 3);
+  private final static ServiceDate SD4 = new ServiceDate(2020, 10, 4);
+  private final static ServiceDate SD1_COPY = new ServiceDate(2020, 10, 1);
+
+  private static final LocalDate D2020_10_21 = LocalDate.of(2020, 10, 21);
+  private static final LocalDate D2020_11_01 = LocalDate.of(2020, 11, 1);
+  private static final LocalDate D2020_11_03 = LocalDate.of(2020, 11, 3);
+  private static final LocalDate D2020_11_27 = LocalDate.of(2020, 11, 27);
+  private static final LocalDate D2020_11_30 = LocalDate.of(2020, 11, 30);
+  private static final LocalDate D2020_12_22 = LocalDate.of(2020, 12, 22);
+  private static final LocalDate D2020_12_24 = LocalDate.of(2020, 12, 24);
+  private static final LocalDate D2020_12_31 = LocalDate.of(2020, 12, 31);
+
+  private static final String OP_1 = "OP-1";
+  private static final String OP_2 = "OP-2";
+  private static final String OP_3 = "OP-3";
+
+  private static final String OP_DAY_1 = "OD-1";
+  private static final String OP_DAY_2 = "OD-2";
+
+  private static final String DAY_TYPE_1 = "D1";
+  private static final String DAY_TYPE_2 = "D2";
+  private static final String DAY_TYPE_3 = "D3";
+  private static final String DAY_TYPE_4 = "D4";
+
+  private static final String SJ_1 = "SJ-1";
+  private static final String SJ_2 = "SJ-2";
+  private static final String SJ_3 = "SJ-3";
+  private static final String SJ_4 = "SJ-4";
+  private static final String SJ_5 = "SJ-5";
+  private static final String SJ_6 = "SJ-6";
+
+  private static final Boolean AVAILABLE = TRUE;
+  private static final Boolean NOT_AVAILABLE = FALSE;
+
+
+  @Test
+  public void mapDayTypesToLocalDates() {
+    // GIVEN
+    var dayTypes = new HierarchicalMapById<DayType>();
+    var assignments = new HierarchicalMultimap<String, DayTypeAssignment>();
+    var periods = new HierarchicalMapById<OperatingPeriod>();
+
+    // Simple assignment on 21.10.2020
+    dayTypes.add(createDayType(DAY_TYPE_1));
+    assignments.add(DAY_TYPE_1, createDayTypeAssignment(DAY_TYPE_1, D2020_10_21, AVAILABLE));
+
+
+    // Skip DAY_TYPE_2  - Should support dayTypes which is not assigned any value
+    dayTypes.add(createDayType(DAY_TYPE_2));
+
+    // DayType 3 - Schedule in November
+    {
+      // Every day in November, except 6. - 23
+      dayTypes.add(createDayType(DAY_TYPE_3, EVERYDAY));
+      periods.add(createOperatingPeriod(OP_1, D2020_11_01, D2020_11_30));
+      assignments.add(DAY_TYPE_3, createDayTypeAssignment(DAY_TYPE_3, OP_1, AVAILABLE));
+      // Except 06.11.2020 to 23.11.2020
+      periods.add(createOperatingPeriod(OP_2, D2020_11_03, D2020_11_27));
+      assignments.add(DAY_TYPE_3, createDayTypeAssignment(DAY_TYPE_3, OP_2, NOT_AVAILABLE));
+    }
+
+    // All weekdays in December (except 24.12, se above)
+    {
+      dayTypes.add(createDayType(DAY_TYPE_4, WEEKDAYS));
+      periods.add(createOperatingPeriod(OP_3, D2020_12_22, D2020_12_31));
+      assignments.add(DAY_TYPE_4, createDayTypeAssignment(DAY_TYPE_4, OP_3, AVAILABLE));
+      // Do not run service on christmas eve
+      assignments.add(DAY_TYPE_4, createDayTypeAssignment(DAY_TYPE_4, D2020_12_24, NOT_AVAILABLE));
+    }
+
+    // WHEN - create calendar
+    var result = CalendarMapper.mapDayTypesToLocalDates(dayTypes, assignments, periods);
+
+
+    // THEN - verify
+    System.out.println(result);
+
+    assertEquals("[2020-10-21]", toStr(result, DAY_TYPE_1));
+    assertEquals("[]", toStr(result, DAY_TYPE_2));
+    assertEquals(
+        "[2020-11-01, 2020-11-02, 2020-11-28, 2020-11-29, 2020-11-30]",
+        toStr(result, DAY_TYPE_3));
+    assertEquals(
+        "[2020-12-22, 2020-12-23, 2020-12-25, 2020-12-28, 2020-12-29, 2020-12-30, 2020-12-31]",
+        toStr(result, DAY_TYPE_4)
+    );
+  }
+
+  private <E> String toStr(Map<String, Set<ServiceDate>> result, String key) {
+    return result.get(key).stream().sorted().collect(Collectors.toList()).toString();
+  }
+
+  @Test
+  public void mapDatesToServiceId() {
+    // given
+    var input = List.of(
+        Set.of(SD1),
+        // Duplicate copy
+        Set.of(SD1_COPY),
+        Set.of(SD2, SD3),
+        // Duplicate exact same, but different collection in reverse order
+        new HashSet<>(Arrays.asList(SD3, SD2)),
+        Set.of(SD3, SD4, SD1),
+        Set.of(SD4, SD1_COPY, SD3)
+    );
+    final IdProducer idProducer = new IdProducer();
+
+    // When
+    var result = CalendarMapper.mapDatesToServiceId(input, idProducer::newId);
+
+    // Then
+    assertEquals(new AgencyAndId(FEED, "1"), result.get(Set.of(SD1)));
+    assertEquals(new AgencyAndId(FEED, "1"), result.get(Set.of(SD1_COPY)));
+    assertEquals(new AgencyAndId(FEED, "2"), result.get(Set.of(SD3, SD2)));
+    assertEquals(new AgencyAndId(FEED, "3"), result.get(Set.of(SD1, SD3, SD4)));
+  }
+
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void createDatedServiceJourneyCalendar() {
+    // Given
+    HierarchicalMapById<DatedServiceJourney> dsjById = new HierarchicalMapById<>();
+    HierarchicalMapById<OperatingDay> opDaysById = new HierarchicalMapById<>();
+
+    dsjById.add(createDatedServiceJourney("ANY-ID-1", OP_DAY_1, SJ_1));
+    dsjById.add(createDatedServiceJourney("ANY-ID-2", OP_DAY_2, SJ_1));
+
+    opDaysById.add(createOperatingDay(OP_DAY_1, D2020_10_21));
+    opDaysById.add(createOperatingDay(OP_DAY_2, D2020_12_24));
+
+    // When
+    var result = CalendarMapper.createDatedServiceJourneyCalendar(dsjById, opDaysById);
+
+    // Then
+    assertEquals(Set.of(new ServiceDate(D2020_10_21), new ServiceDate(D2020_12_24)), result.get(SJ_1));
+  }
+
+
+  @Test
+  public void tripServiceAlterationsBySJId() {
+    // Given
+    var dsjById = new HierarchicalMapById<DatedServiceJourney>();
+
+    // Map empty collection
+    var result = CalendarMapper.tripServiceAlterationsBySJId(dsjById);
+    assertTrue(result.isEmpty());
+
+    // Add some data
+    dsjById.add(createDatedServiceJourney("1", OP_DAY_1, SJ_1));
+    dsjById.add(createDatedServiceJourney("2", OP_DAY_1, SJ_2, PLANNED));
+    dsjById.add(createDatedServiceJourney("3", OP_DAY_1, SJ_3, REPLACED));
+    dsjById.add(createDatedServiceJourney("4", OP_DAY_1, SJ_4, CANCELLATION));
+    dsjById.add(createDatedServiceJourney("5", OP_DAY_1, SJ_5, EXTRA_JOURNEY));
+    dsjById.add(createDatedServiceJourney("6", OP_DAY_1, SJ_6, PLANNED));
+    dsjById.add(createDatedServiceJourney("7", OP_DAY_2, SJ_6));
+
+    result = CalendarMapper.tripServiceAlterationsBySJId(dsjById);
+
+    assertEquals(TripServiceAlteration.planned, result.get(SJ_1));
+    assertEquals(TripServiceAlteration.planned, result.get(SJ_2));
+    assertEquals(TripServiceAlteration.replaced, result.get(SJ_3));
+    assertEquals(TripServiceAlteration.cancellation, result.get(SJ_4));
+    assertEquals(TripServiceAlteration.extraJourney, result.get(SJ_5));
+    assertEquals(TripServiceAlteration.planned, result.get(SJ_6));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void tripServiceAlterationsBySJIdMixedAltNotAllowed() {
+    var dsjById = new HierarchicalMapById<DatedServiceJourney>();
+    dsjById.add(createDatedServiceJourney("1", OP_DAY_1, SJ_1));
+    dsjById.add(createDatedServiceJourney("2", OP_DAY_1, SJ_1, REPLACED));
+    CalendarMapper.tripServiceAlterationsBySJId(dsjById);
+  }
+
+
+  public static class IdProducer {
+    int i = 0;
+    public AgencyAndId newId() {
+      return new AgencyAndId("F", Integer.toString(++i));
+    }
+  }
+}

--- a/src/test/java/org/opentripplanner/netex/mapping/calendar/DayOfWeekMapperTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/calendar/DayOfWeekMapperTest.java
@@ -1,0 +1,80 @@
+package org.opentripplanner.netex.mapping.calendar;
+
+import org.junit.Test;
+import org.rutebanken.netex.model.DayOfWeekEnumeration;
+
+import java.time.DayOfWeek;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.opentripplanner.netex.mapping.calendar.DayOfWeekMapper.mapDayOfWeek;
+import static org.opentripplanner.netex.mapping.calendar.DayOfWeekMapper.mapDayOfWeeks;
+
+public class DayOfWeekMapperTest {
+
+  @Test
+  public void mapDayOfWeekAllValuesTest() {
+    assertEquals(Set.of(DayOfWeek.MONDAY), mapDayOfWeek(DayOfWeekEnumeration.MONDAY));
+    assertEquals(Set.of(DayOfWeek.TUESDAY), mapDayOfWeek(DayOfWeekEnumeration.TUESDAY));
+    assertEquals(Set.of(DayOfWeek.WEDNESDAY), mapDayOfWeek(DayOfWeekEnumeration.WEDNESDAY));
+    assertEquals(Set.of(DayOfWeek.THURSDAY), mapDayOfWeek(DayOfWeekEnumeration.THURSDAY));
+    assertEquals(Set.of(DayOfWeek.FRIDAY), mapDayOfWeek(DayOfWeekEnumeration.FRIDAY));
+    assertEquals(Set.of(DayOfWeek.SATURDAY), mapDayOfWeek(DayOfWeekEnumeration.SATURDAY));
+    assertEquals(Set.of(DayOfWeek.SUNDAY), mapDayOfWeek(DayOfWeekEnumeration.SUNDAY));
+    assertEquals(Set.of(), mapDayOfWeek(DayOfWeekEnumeration.NONE));
+    assertEquals(
+        Set.of(
+            DayOfWeek.MONDAY,
+            DayOfWeek.TUESDAY,
+            DayOfWeek.WEDNESDAY,
+            DayOfWeek.THURSDAY,
+            DayOfWeek.FRIDAY
+        ),
+        mapDayOfWeek(DayOfWeekEnumeration.WEEKDAYS)
+    );
+    assertEquals(
+        Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY),
+        mapDayOfWeek(DayOfWeekEnumeration.WEEKEND)
+    );
+    assertEquals(
+        EnumSet.allOf(DayOfWeek.class),
+        mapDayOfWeek(DayOfWeekEnumeration.EVERYDAY));
+  }
+
+  @Test
+  public void mapDayOfWeekExistForAllValues() {
+    for (DayOfWeekEnumeration it : DayOfWeekEnumeration.values()) {
+      var result = mapDayOfWeek(it);
+
+      if(it == DayOfWeekEnumeration.NONE) {
+        assertEquals(Set.of(), result);
+      }
+      else {
+        assertTrue(result.size() > 0);
+        assertFalse(result.contains(null));
+      }
+    }
+  }
+
+  @Test
+  public void mapDayOfWeeksTest() {
+    assertEquals(
+        Set.of(DayOfWeek.MONDAY),
+        mapDayOfWeeks(List.of(DayOfWeekEnumeration.MONDAY))
+    );
+    assertEquals(
+        Set.of(DayOfWeek.MONDAY),
+        mapDayOfWeeks(List.of(DayOfWeekEnumeration.MONDAY, DayOfWeekEnumeration.MONDAY))
+    );
+    assertEquals(
+        Set.of(DayOfWeek.WEDNESDAY, DayOfWeek.SATURDAY, DayOfWeek.SUNDAY),
+        mapDayOfWeeks(List.of(
+            DayOfWeekEnumeration.WEEKEND, DayOfWeekEnumeration.WEDNESDAY
+        ))
+    );
+  }
+}

--- a/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAndServiceJourneyIdTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAndServiceJourneyIdTest.java
@@ -1,0 +1,44 @@
+package org.opentripplanner.netex.mapping.calendar;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DayTypeAndServiceJourneyIdTest {
+  private static final String DT_ID = "DT-1";
+  private static final String SJ_ID = "SJ-1";
+  private static final String DT_OTHER_ID = "DT-99";
+  private static final String SJ_OTHER_ID = "SJ-99";
+
+  @Test
+  public void testToStringAndGetters() {
+    // To string should be easy to read for debugging
+    DayTypeAndServiceJourneyId subject = new DayTypeAndServiceJourneyId(DT_ID, SJ_ID);
+
+    assertEquals(SJ_ID, subject.serviceJourneyId());
+    assertEquals(DT_ID, subject.dayTypeId());
+    assertTrue(subject.toString().contains("sj=" + SJ_ID));
+    assertTrue(subject.toString().contains("dt=" + DT_ID));
+  }
+
+  @SuppressWarnings("SimplifiableAssertion")
+  @Test
+  public void testEquals() {
+    // Assert is safe to use in a Set or HashMap
+    var a = new DayTypeAndServiceJourneyId(DT_ID, SJ_ID);
+    var same = new DayTypeAndServiceJourneyId(DT_ID, SJ_ID);
+    var sjDiff = new DayTypeAndServiceJourneyId(DT_OTHER_ID, SJ_ID);
+    var dtDiff = new DayTypeAndServiceJourneyId(DT_ID, SJ_OTHER_ID);
+
+    assertEquals(a.hashCode(), same.hashCode());
+    assertEquals(a, same);
+
+    assertFalse(a.equals(sjDiff));
+    assertFalse(a.equals(dtDiff));
+
+    assertTrue(a.hashCode() != sjDiff.hashCode());
+    assertTrue(a.hashCode() != dtDiff.hashCode());
+  }
+}

--- a/src/test/java/org/opentripplanner/netex/mapping/calendar/ServiceCalendarBuilderTest.java
+++ b/src/test/java/org/opentripplanner/netex/mapping/calendar/ServiceCalendarBuilderTest.java
@@ -1,0 +1,194 @@
+package org.opentripplanner.netex.mapping.calendar;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opentripplanner.model.AgencyAndId;
+import org.opentripplanner.model.ServiceCalendarDate;
+import org.opentripplanner.model.TripServiceAlteration;
+import org.opentripplanner.netex.loader.NetexDao;
+import org.opentripplanner.netex.mapping.AgencyAndIdFactory;
+import org.rutebanken.netex.model.DayTypeRefStructure;
+import org.rutebanken.netex.model.DayTypeRefs_RelStructure;
+import org.rutebanken.netex.model.ServiceJourney;
+
+import javax.xml.bind.JAXBElement;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.lang.Boolean.TRUE;
+import static org.junit.Assert.assertEquals;
+import static org.opentripplanner.netex.NetexTestDataSupport.createDatedServiceJourney;
+import static org.opentripplanner.netex.NetexTestDataSupport.createDayType;
+import static org.opentripplanner.netex.NetexTestDataSupport.createDayTypeAssignment;
+import static org.opentripplanner.netex.NetexTestDataSupport.createOperatingDay;
+import static org.opentripplanner.netex.NetexTestDataSupport.createOperatingPeriod;
+import static org.opentripplanner.netex.NetexTestDataSupport.jaxbElement;
+import static org.rutebanken.netex.model.DayOfWeekEnumeration.FRIDAY;
+import static org.rutebanken.netex.model.DayOfWeekEnumeration.MONDAY;
+import static org.rutebanken.netex.model.DayOfWeekEnumeration.SATURDAY;
+import static org.rutebanken.netex.model.DayOfWeekEnumeration.SUNDAY;
+import static org.rutebanken.netex.model.DayOfWeekEnumeration.WEDNESDAY;
+import static org.rutebanken.netex.model.DayOfWeekEnumeration.WEEKDAYS;
+import static org.rutebanken.netex.model.DayOfWeekEnumeration.WEEKEND;
+import static org.rutebanken.netex.model.ServiceAlterationEnumeration.PLANNED;
+
+public class ServiceCalendarBuilderTest {
+  private static final LocalDate D2020_11_02 = LocalDate.of(2020, 11, 2);
+  private static final LocalDate D2020_11_08 = LocalDate.of(2020, 11, 8);
+
+  private static final String OP_1 = "OP-1";
+
+  private static final String OP_DAY_1 = "OD-1";
+
+  private static final String DAY_TYPE_1 = "D1";
+  private static final String DAY_TYPE_2 = "D2";
+  private static final String DAY_TYPE_3 = "D3";
+  private static final String DAY_TYPE_4 = "D4";
+  private static final String DAY_TYPE_5 = "D5";
+
+  private static final String SJ_1 = "SJ-1";
+  private static final String SJ_2 = "SJ-2";
+  private static final String SJ_3 = "SJ-3";
+  private static final String SJ_4 = "SJ-4";
+  private static final String SJ_5 = "SJ-5";
+
+  private static final Boolean AVAILABLE = TRUE;
+
+  // Add Calendar(DayType, DayTypeAssignment, OperationPeriod) to level 1
+  private final NetexDao netexDaoLvl1 = NetexDao.createForTest(null);
+
+  // Add ServiceJourneys to level 2 A
+  private final NetexDao netexDaoLvl2A = NetexDao.createForTest(netexDaoLvl1);
+
+  // Add ServiceJourneys to level 2 B, data here should not interfare with data in A
+  private final NetexDao netexDaoLvl2B = NetexDao.createForTest(netexDaoLvl1);
+
+
+  @Before
+  public void setup() {
+    AgencyAndIdFactory.setAgencyId("F");
+  }
+
+  @Test
+  public void tripServiceAlterationsBySJId() {
+    netexDaoLvl1.operatingDaysById.add(createOperatingDay(OP_DAY_1, D2020_11_02));
+    netexDaoLvl2A.datedServiceJourneyById.add(createDatedServiceJourney("1", OP_DAY_1, SJ_2, PLANNED));
+
+    ServiceCalendarBuilder builder = new ServiceCalendarBuilder();
+    builder.buildCalendar(netexDaoLvl1);
+
+    builder.pushCache();
+    builder.buildCalendar(netexDaoLvl2A);
+    assertEquals(TripServiceAlteration.planned , builder.tripServiceAlterationsBySJId().get(SJ_2));
+    builder.popCache();
+    builder.pushCache();
+    builder.buildCalendar(netexDaoLvl2B);
+    assertEquals("{}" , builder.tripServiceAlterationsBySJId().toString());
+    builder.popCache();
+  }
+
+  @Test
+  public void buildCalendar() {
+    setupBuildCalendar();
+    ServiceCalendarBuilder builder = new ServiceCalendarBuilder();
+
+    builder.buildCalendar(netexDaoLvl1);
+
+    builder.pushCache();
+    builder.buildCalendar(netexDaoLvl2A);
+    verifyBuildCalendarLevel2A(builder);
+    var serviceId_SJ2 = builder.serviceIdByServiceJourneyId().get(SJ_2);
+    builder.popCache();
+
+    builder.pushCache();
+    builder.buildCalendar(netexDaoLvl2B);
+    verifyBuildCalendarLevel2B(builder, serviceId_SJ2);
+    builder.popCache();
+  }
+
+  private void setupBuildCalendar() {
+
+    netexDaoLvl1.dayTypeById.add(createDayType(DAY_TYPE_1, WEEKDAYS));
+    netexDaoLvl1.dayTypeById.add(createDayType(DAY_TYPE_2, WEEKEND));
+    netexDaoLvl1.dayTypeById.add(createDayType(DAY_TYPE_3, SATURDAY));
+    netexDaoLvl1.dayTypeById.add(createDayType(DAY_TYPE_4, SUNDAY));
+    netexDaoLvl1.dayTypeById.add(createDayType(DAY_TYPE_5, MONDAY, WEDNESDAY, FRIDAY));
+
+    netexDaoLvl1.operatingPeriodById.add(createOperatingPeriod(OP_1, D2020_11_02, D2020_11_08));
+
+    // Create DayTypeAssignments for the first week in november for all dayTypes
+    List.of(DAY_TYPE_1, DAY_TYPE_2, DAY_TYPE_3, DAY_TYPE_4, DAY_TYPE_5).forEach(dt ->
+        netexDaoLvl1.dayTypeAssignmentByDayTypeId.add(dt, createDayTypeAssignment(dt, OP_1, AVAILABLE))
+    );
+
+    // SJ 1 : Mon - Fri (Weekdays)
+    // SJ 2 : Sat, Sun (Weekend)
+    // SJ 3 : Mon, Wed, Thu
+    // SJ 4 : Sat, Sun - Same as SJ 2, but combining DayType 4 and 5
+    netexDaoLvl2A.serviceJourneyById.add(createServiceJourney(SJ_1, DAY_TYPE_1));
+    netexDaoLvl2A.serviceJourneyById.add(createServiceJourney(SJ_2, DAY_TYPE_2));
+    netexDaoLvl2A.serviceJourneyById.add(createServiceJourney(SJ_3, DAY_TYPE_3, DAY_TYPE_4));
+    netexDaoLvl2A.serviceJourneyById.add(createServiceJourney(SJ_4, DAY_TYPE_3, DAY_TYPE_5));
+    netexDaoLvl2B.serviceJourneyById.add(createServiceJourney(SJ_5, DAY_TYPE_5));
+  }
+
+  private void verifyBuildCalendarLevel2A(ServiceCalendarBuilder builder) {
+    List<ServiceCalendarDate> calendarDates = builder.calendarDates();
+
+    var serviceId1 = builder.serviceIdByServiceJourneyId().get(SJ_1);
+    var serviceId2 = builder.serviceIdByServiceJourneyId().get(SJ_2);
+    var serviceId3 = builder.serviceIdByServiceJourneyId().get(SJ_3);
+    var serviceId4 = builder.serviceIdByServiceJourneyId().get(SJ_4);
+
+    assertEquals(
+        // Mon - Fri
+        "2020-11-02, 2020-11-03, 2020-11-04, 2020-11-05, 2020-11-06",
+        toStr(serviceId1, calendarDates)
+    );
+    assertEquals(
+        // Weekend
+        "2020-11-07, 2020-11-08",
+        toStr(serviceId2, calendarDates)
+    );
+
+    // Test reuse of DayTypes, in another combination. Expect [Mon, Wed, Fri] + [Sat]
+    assertEquals(
+        "2020-11-02, 2020-11-04, 2020-11-06, 2020-11-07",
+        toStr(serviceId4, calendarDates)
+    );
+
+    // SJ 2 and 3 run on the same days(Sat, Sun), there should be just ONE serviceId used by both
+    assertEquals(serviceId2, serviceId3);
+  }
+
+  private void verifyBuildCalendarLevel2B(ServiceCalendarBuilder builder, AgencyAndId sameIdAsSJ2) {
+    var serviceId4 = builder.serviceIdByServiceJourneyId().get(SJ_5);
+
+    assertEquals(
+        // Mon, Wed, Fri
+        "2020-11-02, 2020-11-04, 2020-11-06",
+        toStr(serviceId4, builder.calendarDates())
+    );
+  }
+
+  private String toStr(AgencyAndId serviceId, Collection<ServiceCalendarDate> list) {
+    return list.stream()
+        .filter(it -> it.getServiceId().equals(serviceId))
+        .map(it -> it.getDate().toString())
+        .sorted()
+        .collect(Collectors.joining(", "));
+  }
+
+  private static ServiceJourney createServiceJourney(String sjId, String ... dayTypes) {
+    var dtList = new ArrayList<JAXBElement<? extends DayTypeRefStructure>>();
+    for (String it : dayTypes) {
+      dtList.add(jaxbElement(new DayTypeRefStructure().withRef(it), DayTypeRefStructure.class));
+    }
+    return new ServiceJourney()
+        .withId(sjId)
+        .withDayTypes(new DayTypeRefs_RelStructure().withDayTypeRef(dtList));
+  }
+}


### PR DESCRIPTION
 1. The most critical is that days for DAY_TYPES used in more than on SJ some times get merged together, creating services with "extra" days in it. This was introduced when adding support for DSJ.
 2. If a DayType applies to EVERYDAY in a period, then merging to periods( A minus B) using DayTypeAssignments result in all days in period A + B, B is added not subtracted. This is a bug have "always" been there.

Extensive unit-tests are added to the Calendar mapping with 100% branch coverage. Also the code is changed to use unmodifiable sets to prevent bugs like the first one.