### PR TITLE
Fix SLF4J/JUL configuration

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -41,7 +41,7 @@ public class OTPMain {
     private static final Logger LOG = LoggerFactory.getLogger(OTPMain.class);
 
     static {
-        // Remove existing handlers attached to the j.u.l root logger
+        // Remove existing handlers attached to the java.util.logging (j.u.l) root logger
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         // Bridge j.u.l (used by Jersey) to the SLF4J root logger, so all logging goes through the same API
         SLF4JBridgeHandler.install();

--- a/src/main/java/org/opentripplanner/standalone/OTPMain.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPMain.java
@@ -26,6 +26,7 @@ import org.opentripplanner.routing.services.GraphService;
 import org.opentripplanner.visualizer.GraphVisualizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 /**
  * This is the main entry point to OpenTripPlanner. It allows both building graphs and starting up an OTP server
@@ -38,6 +39,13 @@ import org.slf4j.LoggerFactory;
 public class OTPMain {
 
     private static final Logger LOG = LoggerFactory.getLogger(OTPMain.class);
+
+    static {
+        // Remove existing handlers attached to the j.u.l root logger
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        // Bridge j.u.l (used by Jersey) to the SLF4J root logger, so all logging goes through the same API
+        SLF4JBridgeHandler.install();
+    }
 
     private final CommandLineParameters params;
     public OTPServer otpServer = null;


### PR DESCRIPTION
OTP manages log messages through the SLF4J logging framework and uses LogBack as a concrete logger implementation. However some third-party libraries used by OTP output log messages through Java Unified Logging (JUL).
These log messages should be redirected to SLF4J using the jul-slf4j bridge, but this is currently not functional in OTP1.
This results in log messages at INFO level being output to stderr and interpreted by StackDriver as ERROR-level messages 
Examples:
When the OTP1 graph builder starts, the following messages are output to stderr:
INFO: Database closed
INFO: dataFileCache open start

Root cause:
1. HSQLDB reconfigure JUL at startup time.
--> This can be disabled by setting the system property: -Dhsqldb.reconfig_logging=false
See this other PR for a fix: https://github.com/entur/otp-deployment-config/pull/26

2 The initialisation of SLF4J is ignored because it runs too late in the startup process
(https://github.com/entur/OpenTripPlanner/blob/46d04264dea8886604f23689329e5cd1f2d84888/src/main/java/org/opentripplanner/standalone/OTPApplication.java#L39)
--> SLF4J should be initialized in OTPMain.
This is the purpose of this PR.